### PR TITLE
Break the ffmpeg command line out to a list before submitting to subprocess

### DIFF
--- a/TabloToGo.v1.py
+++ b/TabloToGo.v1.py
@@ -117,7 +117,7 @@ def get_video(IPADDR, VIDEOID, DIRECTORY, TEMPDIR, FFMPEG, FILENAME, DEBUG, TEST
         counter = counter + 1
         if TESTING and counter > 5:
             valid = 0 ## Only process first 5 segmant
-    cmd = FFMPEG+' -y -i "concat:'+concat[:-1]+'" -bsf:a aac_adtstoasc -c copy "'+DIRECTORY+'/'+FILENAME+'.mp4"'
+    cmd = [ FFMPEG, '-y', '-i', 'concat:'+concat[:-1], '-bsf:a', 'aac_adtstoasc', '-c', 'copy', DIRECTORY+'/'+FILENAME+'.mp4' ]
     if ts:
         cmd = FFMPEG+' -y -loglevel panic -i "concat:'+concat[:-1]+'" -c copy "'+DIRECTORY+'/'+FILENAME+'.ts"'
     if DEBUG: print cmd


### PR DESCRIPTION
Tested under OSX 10.11.2 using native python 2.7 and ffmpeg from homebrew.  Haven't hit the error after breaking out the command line to a list.

Fixes #1 
